### PR TITLE
Fix: Update Environment URLs to ensure new endpoints are called corre…

### DIFF
--- a/example-integration/.env
+++ b/example-integration/.env
@@ -8,9 +8,9 @@ APP_SECRET=a19d4fa833f0214aa72a8448aacd8a64
 REDIS_URL=redis://valkey:6379/0
 ###< snc/redis-bundle ###
 
+SANDBOX_MODE=true
 SIGNING_KEY=
 REFRESH_TOKEN=
-PAYMENT_BASE_URL=
 USER_AGENT=
 PARTNER_REFERENCE=
 FAST_CHECKOUT_RETURN_URL=http://localhost:1234/callback/fast-checkout

--- a/example-integration/config/services.yaml
+++ b/example-integration/config/services.yaml
@@ -11,7 +11,7 @@ services:
         autowire: true      # Automatically injects dependencies in your services.
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
         bind:
-          string $baseUrl: '%env(string:PAYMENT_BASE_URL)%'
+          bool $sandboxMode: '%env(bool:SANDBOX_MODE)%'
           string $refreshToken: '%env(REFRESH_TOKEN)%'
           string $signingKey: '%env(SIGNING_KEY)%'
           string $merchantReturnUrl: '%env(MERCHANT_RETURN_URL)%'

--- a/example-integration/src/Service/Service/OmniKassaClient.php
+++ b/example-integration/src/Service/Service/OmniKassaClient.php
@@ -4,6 +4,7 @@ namespace OmniKassa\ExampleIntegration\Service\Service;
 
 use Carbon\CarbonImmutable;
 use nl\rabobank\gict\payments_savings\omnikassa_sdk\endpoint\Endpoint;
+use nl\rabobank\gict\payments_savings\omnikassa_sdk\model\Environment;
 use nl\rabobank\gict\payments_savings\omnikassa_sdk\model\request\InitiateRefundRequest;
 use nl\rabobank\gict\payments_savings\omnikassa_sdk\model\request\MerchantOrder;
 use nl\rabobank\gict\payments_savings\omnikassa_sdk\model\response\AnnouncementResponse;
@@ -24,8 +25,13 @@ class OmniKassaClient implements OmniKassaClientInterface
     private const CACHE_KEY_PREFIX = 'omnikassa_order_';
     private Endpoint $endpoint;
 
-    public function __construct(private CacheItemPoolInterface $cacheItemPool, string $baseUrl, TokenProviderInterface $tokenProvider, string $signingKey)
+    public function __construct(private CacheItemPoolInterface $cacheItemPool, bool $sandboxMode, TokenProviderInterface $tokenProvider, string $signingKey)
     {
+        $baseUrl = Environment::SANDBOX;
+        if (false === $sandboxMode) {
+            $baseUrl = Environment::PRODUCTION;
+        }
+
         $this->endpoint = Endpoint::createInstance(
             $baseUrl,
             new SigningKey($signingKey),

--- a/src/model/Environment.php
+++ b/src/model/Environment.php
@@ -7,6 +7,6 @@ namespace nl\rabobank\gict\payments_savings\omnikassa_sdk\model;
  */
 abstract class Environment
 {
-    public const PRODUCTION = 'https://betalen.rabobank.nl/omnikassa-api/';
-    public const SANDBOX = 'https://betalen.rabobank.nl/omnikassa-api-sandbox/';
+    public const PRODUCTION = 'https://api.pay.rabobank.nl/';
+    public const SANDBOX = 'https://api.pay-sandbox.rabobank.nl/';
 }


### PR DESCRIPTION
…ctly

Fix addresses the issue raised by GErpeldinger:
https://github.com/rabobank-nederland/omnikassa-php-sdk/issues/47

Changed the PRODUCTION and SANDBOX urls to the new API endpoints. Existing endpoints are being sunset. This also solves the issue raised by GErpeldinger for duplicate omnikassa-api insertion. Some endpoints do not require the /omnikassa-api/ infix, so that's why it cannot be added to the 'base url'.

Old:
public const PRODUCTION = 'https://betalen.rabobank.nl/omnikassa-api/' public const SANDBOX = 'https://betalen.rabobank.nl/omnikassa-api-sandbox/'

New:
public const PRODUCTION = 'https://api.pay.rabobank.nl/' public const SANDBOX = 'https://api.pay-sandbox.rabobank.nl/'