### PR TITLE
Revert getAnnouncementData call back to v1

### DIFF
--- a/src/connector/ApiConnector.php
+++ b/src/connector/ApiConnector.php
@@ -98,7 +98,7 @@ class ApiConnector implements Connector
         return $this->performAction(function () use (&$announcement) {
             $this->restTemplate->setToken($announcement->getAuthentication());
 
-            return $this->restTemplate->get(sprintf('%s/order/server/api/v2/events/results/%s', self::OMNIKASSA_INFIX, $announcement->getEventName()));
+            return $this->restTemplate->get(sprintf('%s/order/server/api/events/results/%s', self::OMNIKASSA_INFIX, $announcement->getEventName()));
         });
     }
 

--- a/test/connector/ApiConnectorTest.php
+++ b/test/connector/ApiConnectorTest.php
@@ -77,14 +77,15 @@ class ApiConnectorTest extends TestCase
     {
         $announcement = AnnouncementResponseBuilder::newInstance();
         $expectedResponse = $this->makeAnnouncementResponse($announcement->getEventName());
+        $v1Endpoint = 'omnikassa-api/order/server/api/events/results/'.$announcement->getEventName();
 
         $this->prepareTokenProviderWithAccessToken($this->accessToken);
-        Phake::when($this->restTemplate)->get('omnikassa-api/order/server/api/v2/events/results/'.$announcement->getEventName())->thenReturn($expectedResponse);
+        Phake::when($this->restTemplate)->get($v1Endpoint)->thenReturn($expectedResponse);
 
         $actualResponse = $this->connector->getAnnouncementData($announcement);
 
         Phake::verify($this->restTemplate)->setToken('MyJwt');
-        Phake::verify($this->restTemplate)->get('omnikassa-api/order/server/api/v2/events/results/'.$announcement->getEventName());
+        Phake::verify($this->restTemplate)->get($v1Endpoint);
 
         $this->assertEquals($expectedResponse, $actualResponse);
     }


### PR DESCRIPTION
Revert getAnnouncementData call back to v1 due to signature changes in v2


V2 changes will need some additional changes, so for now move back to the (deprecated) v1 call. We will likely be using the [existing PR](https://github.com/rabobank-nederland/omnikassa-php-sdk/pull/49) as base for that change. 